### PR TITLE
SCRUM-88 Interfaceの拡張

### DIFF
--- a/Assets/Scripts/Interface/IPlayerSelectable.cs
+++ b/Assets/Scripts/Interface/IPlayerSelectable.cs
@@ -1,4 +1,18 @@
+using UnityEngine;
+
 public interface IPlayerSelectable
 {
-	bool IsSelected();
+    // 選択先のタイプ
+    public enum SelectType
+    {
+        NONE, // あるだけ
+        GIMMICK, // 取得可能オブジェクト
+        ENEMY // 敵
+    }
+
+    bool IsSelected();
+
+    SelectType GetSelectType();
+
+    Vector3 GetBoundsSize();
 }

--- a/Assets/Scripts/SelectableBase.meta
+++ b/Assets/Scripts/SelectableBase.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 15b827cb4c7f9d24ca0028094ab1d674
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/SelectableBase/SelectableEnemyBase.cs
+++ b/Assets/Scripts/SelectableBase/SelectableEnemyBase.cs
@@ -1,0 +1,41 @@
+using UnityEngine;
+
+public class SelectableEnemyBase : MonoBehaviour , IPlayerSelectable
+{
+    protected IPlayerSelectable.SelectType selectType = IPlayerSelectable.SelectType.NONE;
+
+    protected void Start()
+    {
+        selectType = IPlayerSelectable.SelectType.ENEMY;
+    }
+
+    // インターフェースメソッド
+    // 選択可能かどうかを返すメソッド
+    public bool IsSelected()
+    {
+        // 戻り値は動的に変えれるようにする？
+        return true;
+    }
+
+    // インターフェースメソッド
+    // 自分のタイプを返却
+    public IPlayerSelectable.SelectType GetSelectType()
+    {
+        return selectType;
+    }
+
+    // インターフェースメソッド
+    // 自分の幅、高さのサイズを取得
+    public Vector3 GetBoundsSize()
+    {
+        var renderer = GetComponent<Renderer>();
+        Vector3 boundsSize = transform.localScale;
+
+        if (renderer != null)
+        {
+            boundsSize = renderer.bounds.size;
+        }
+
+        return boundsSize;
+    }
+}

--- a/Assets/Scripts/SelectableBase/SelectableEnemyBase.cs.meta
+++ b/Assets/Scripts/SelectableBase/SelectableEnemyBase.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d179d2a9f13700147b442aa90495a572

--- a/Assets/Scripts/SelectableBase/SelectableGimmickObjectBase.cs
+++ b/Assets/Scripts/SelectableBase/SelectableGimmickObjectBase.cs
@@ -1,0 +1,41 @@
+using UnityEngine;
+
+public class SelectableGimmickObjectBase : MonoBehaviour , IPlayerSelectable
+{
+    protected IPlayerSelectable.SelectType selectType = IPlayerSelectable.SelectType.NONE;
+
+    protected void Start()
+    {
+        selectType = IPlayerSelectable.SelectType.GIMMICK;
+    }
+
+    // インターフェースメソッド
+    // 選択可能かどうかを返すメソッド
+    public bool IsSelected()
+    {
+        // 戻り値は動的に変えれるようにする？
+        return true;
+    }
+
+    // インターフェースメソッド
+    // 自分のタイプを返却
+    public IPlayerSelectable.SelectType GetSelectType()
+    {
+        return selectType;
+    }
+
+    // インターフェースメソッド
+    // 自分の幅、高さのサイズを取得
+    public Vector3 GetBoundsSize()
+    {
+        var renderer = GetComponent<Renderer>();
+        Vector3 boundsSize = transform.localScale;
+
+        if (renderer != null)
+        {
+            boundsSize = renderer.bounds.size;
+        }
+
+        return boundsSize;
+    }
+}

--- a/Assets/Scripts/SelectableBase/SelectableGimmickObjectBase.cs.meta
+++ b/Assets/Scripts/SelectableBase/SelectableGimmickObjectBase.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 246a0b86eb1910c4e95ed9133a76d5ed


### PR DESCRIPTION
## チケット
https://projecteden.atlassian.net/browse/SCRUM-88

## 概要
オブジェクトの選択のためのInterfaceの拡張

## 対応内容
IPlayerSelectableのInterfaceを以下のように拡張
・オブジェクトのタイプの取得
・オブジェクトの幅の取得

それに伴い、Intarfaceの処理を実行するためのベースクラスを作成

## 影響範囲
なし