### PR TITLE
SCRUM-67　敵の死亡処理が発動しないバグ修正

### DIFF
--- a/Assets/Scenes/AITest.unity
+++ b/Assets/Scenes/AITest.unity
@@ -807,6 +807,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3679744720166685892, guid: bec916380ddc5c64695014f2ab91d970,
         type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 3679744720166685892, guid: bec916380ddc5c64695014f2ab91d970,
+        type: 3}
       propertyPath: m_IsActive
       value: 1
       objectReference: {fileID: 0}
@@ -943,6 +948,53 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c12dc9a7be07a9c4584388ece202df5c, type: 3}
+--- !u!1 &1134747747
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1134747749}
+  - component: {fileID: 1134747748}
+  m_Layer: 0
+  m_Name: PlayerPowerManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1134747748
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1134747747}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f0982207792bd9a4e98d8ec73075eebf, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  powerGauge: 5
+  lightningPowerUpValue: 1
+  godPowerUpValue: 2
+--- !u!4 &1134747749
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1134747747}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1238010611
 GameObject:
   m_ObjectHideFlags: 0
@@ -1539,6 +1591,74 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!1001 &2037297664
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 3657032105539696163, guid: b085d145631ce824b82f8fcea9738ab1,
+        type: 3}
+      propertyPath: m_Name
+      value: Obj
+      objectReference: {fileID: 0}
+    - target: {fileID: 6370625171675519867, guid: b085d145631ce824b82f8fcea9738ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 20.22
+      objectReference: {fileID: 0}
+    - target: {fileID: 6370625171675519867, guid: b085d145631ce824b82f8fcea9738ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6370625171675519867, guid: b085d145631ce824b82f8fcea9738ab1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 10.71
+      objectReference: {fileID: 0}
+    - target: {fileID: 6370625171675519867, guid: b085d145631ce824b82f8fcea9738ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6370625171675519867, guid: b085d145631ce824b82f8fcea9738ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6370625171675519867, guid: b085d145631ce824b82f8fcea9738ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6370625171675519867, guid: b085d145631ce824b82f8fcea9738ab1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6370625171675519867, guid: b085d145631ce824b82f8fcea9738ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6370625171675519867, guid: b085d145631ce824b82f8fcea9738ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6370625171675519867, guid: b085d145631ce824b82f8fcea9738ab1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b085d145631ce824b82f8fcea9738ab1, type: 3}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
@@ -1555,3 +1675,5 @@ SceneRoots:
   - {fileID: 1415207576}
   - {fileID: 705690052}
   - {fileID: 785105396}
+  - {fileID: 1134747749}
+  - {fileID: 2037297664}

--- a/Assets/Scripts/Enemy/Debug/TempAttackCollider.cs
+++ b/Assets/Scripts/Enemy/Debug/TempAttackCollider.cs
@@ -9,7 +9,12 @@ public class TempAttackCollider : MonoBehaviour
         IDamageable damageable = other.GetComponent<IDamageable>();
         if (damageable != null)
         {
-            damageable.Damage(attackDamage);
+            bool targetDead = false;
+            targetDead = damageable.Damage(attackDamage);
+            if (targetDead)
+            {
+                damageable.Death();
+            }
         }
     }
 }


### PR DESCRIPTION
## チケット
https://projecteden.atlassian.net/browse/SCRUM-67

## 概要
敵の死亡処理の修正

## 対応内容
敵テストシーンの仮プレイヤー攻撃の処理に死亡関数呼び出す処理追加