### PR TITLE
SCRUM-134 クロノ・エンド使用時に吹っ飛ぶ動作になる不具合

### DIFF
--- a/Assets/Scripts/Enemy/EnemyGruntBasic/EnemyGrunt.cs
+++ b/Assets/Scripts/Enemy/EnemyGruntBasic/EnemyGrunt.cs
@@ -8,6 +8,11 @@ using System.Threading;
 using Cysharp.Threading.Tasks.Triggers;
 using Unity.VisualScripting;
 
+struct KronoEndGruntData
+{
+    public bool wasStopped;
+}
+
 public partial class EnemyGrunt : EnemyBase
 {
     ImtStateMachine<EnemyGrunt> stateMachine;
@@ -34,6 +39,8 @@ public partial class EnemyGrunt : EnemyBase
     private Color originalColor;
 
     private Vector3 playerPos;
+
+    private KronoEndGruntData kronoEndData;
 
     [SerializeField] private float chaseSpeed = 15;
     [SerializeField] private float patrolSpeed = 10;
@@ -71,6 +78,7 @@ public partial class EnemyGrunt : EnemyBase
     private bool isAttacking = false;
     private bool isRangedAttacking = false;
     private bool isDamaged = false;
+    private bool isFrozen = false;
 
     /// <summary>
     /// AIステートの移動ENUM
@@ -154,6 +162,22 @@ public partial class EnemyGrunt : EnemyBase
     /// </summary>
     protected new virtual void FixedUpdate()
     {
+        if (PlayerKronoEnd.GetIsKronoEnd() && !isFrozen)
+        {
+            isFrozen = true;
+            kronoEndData.wasStopped = navAgent.isStopped;
+            navAgent.isStopped = true;
+            return;
+        }
+        else if(!PlayerKronoEnd.GetIsKronoEnd() && isFrozen)
+        {
+            isFrozen = false;
+            navAgent.isStopped = kronoEndData.wasStopped;
+        }
+        if(isFrozen)
+        {
+            return;
+        }
         stateMachine.Update();
     }
 
@@ -281,7 +305,7 @@ public partial class EnemyGrunt : EnemyBase
             {
                 elapsed += Time.deltaTime;
                 mesh.material.color = Color.Lerp(Color.red, originalColor, elapsed / damageFlashTime);
-                await UniTask.Yield(cancellationToken: token);
+                await TimeControl.KronoYield(token);
             }
 
             isDamaged = false;
@@ -310,7 +334,7 @@ public partial class EnemyGrunt : EnemyBase
         {
             elapsed += Time.deltaTime;
             mesh.material.color = Color.Lerp(Color.magenta, Color.clear, elapsed / deathFadeTime);
-            await UniTask.Yield();
+            await TimeControl.KronoYield();
         }
 
         Destroy(gameObject);
@@ -321,7 +345,7 @@ public partial class EnemyGrunt : EnemyBase
         isAttacking = true;
         attackBox.SetActive(true);
         audioSource.PlayOneShot(swordClip);
-        await UniTask.Delay(TimeSpan.FromSeconds(meleeAttackTime));
+        await TimeControl.KronoDelay(meleeAttackTime);
         attackBox.SetActive(false);
         isAttacking = false;
         ResetAttackCooldown(meleeAttackCooldown).Forget();
@@ -332,29 +356,29 @@ public partial class EnemyGrunt : EnemyBase
         isAttacking = true;
         isRangedAttacking = true;
         navAgent.updateRotation = false;
-        await UniTask.Delay(TimeSpan.FromSeconds(rangedAttackDelay));
+        await TimeControl.KronoDelay(rangedAttackDelay);
         for (int i = 0; i < rangedAttackCount; i++)
         {
-            await UniTask.Delay(TimeSpan.FromSeconds(rangedAttackInterval));
+            await TimeControl.KronoDelay(rangedAttackInterval);
             audioSource.PlayOneShot(gunClip);
             ShootProjectile();
         }
         isRangedAttacking = false;
         navAgent.updateRotation = true;
-        await UniTask.Delay(TimeSpan.FromSeconds(rangedAttackDelay));
+        await TimeControl.KronoDelay(rangedAttackDelay);
         isAttacking = false;
         ResetAttackCooldown(rangedAttackCooldown).Forget();
     }
 
     private async UniTaskVoid ResetPatrol()
     {
-        await UniTask.Delay(TimeSpan.FromSeconds(patrolWaitTime));
+        await TimeControl.KronoDelay(patrolWaitTime);
         canPatrol = true;
     }
 
     private async UniTaskVoid ResetAttackCooldown(float attackCooldown)
     {
-        await UniTask.Delay(TimeSpan.FromSeconds(attackCooldown));
+        await TimeControl.KronoDelay(attackCooldown);
         canAttack = true;
     }
 
@@ -362,7 +386,7 @@ public partial class EnemyGrunt : EnemyBase
     {
         try
         {
-            await UniTask.Delay(TimeSpan.FromSeconds(playerSearchTime), cancellationToken: token);
+            await TimeControl.KronoDelay(playerSearchTime, token);
             playerDetected = false;
             playerInSight = false;
         }

--- a/Assets/Scripts/Interface/IPlayerSelectable.cs
+++ b/Assets/Scripts/Interface/IPlayerSelectable.cs
@@ -2,22 +2,14 @@ using UnityEngine;
 
 public interface IPlayerSelectable
 {
-    // 選択先のタイプ
-    enum SelectType
-    {
-        NONE, // あるだけ
-        GIMMICK, // 取得可能オブジェクト
-        ENEMY // 敵
-    }
-
     // 選択候補かどうかの判定
     void AllowSelection(bool selecttion);
     // 選択タイプを取得するためのメソッド
-    SelectType GetSelectType();
+    SelectableType GetSelectableType();
     // オブジェクトの幅を取得するためのメソッド
     Vector3 GetBoundsSize();
     // 選択したかどうかの判定
-    bool IsSelect { get; set; }
+    bool IsSelect { get; }
     // 選択時に呼び出すメソッド
     void OnSelect();
     // 選択解除時に呼び出すメソッド

--- a/Assets/Scripts/Object/Object.cs
+++ b/Assets/Scripts/Object/Object.cs
@@ -1,16 +1,16 @@
-﻿using DocumentFormat.OpenXml.Office2013.Drawing.Chart;
+using DocumentFormat.OpenXml.Office2013.Drawing.Chart;
 using UnityEngine;
 using static IPlayerSelectable;
 
 public class Object : MonoBehaviour, IPlayerSelectable, IDamageable
 {
-    protected SelectType selectType = SelectType.NONE;
+    protected SelectableType selectType = SelectableType.NONE;
     protected float maxHP = 10f;
     protected float currentHP;
 
     protected void Start()
     {
-        selectType = SelectType.ENEMY;
+        selectType = SelectableType.ENEMY;
         currentHP = maxHP;
     }
 
@@ -24,7 +24,7 @@ public class Object : MonoBehaviour, IPlayerSelectable, IDamageable
 
     // インターフェースメソッド
     // 自分のタイプを返却
-    public SelectType GetSelectType()
+    public SelectableType GetSelectableType()
     {
         return selectType;
     }

--- a/Assets/Scripts/Player/PlayerKronoEnd.cs
+++ b/Assets/Scripts/Player/PlayerKronoEnd.cs
@@ -40,7 +40,8 @@ public class PlayerKronoEnd
         Debug.Log("start KronoEnd");
         // スキル中判定をtrueにする
         isKronoEnd = true;
-        Time.timeScale = 0.01f;
+        // この個所はタイムスケールをいじるのではないようにする。
+        //Time.timeScale = 0.01f;
 
         cts?.Dispose();
         cts = new CancellationTokenSource();
@@ -85,7 +86,7 @@ public class PlayerKronoEnd
     private void ResetTimeScale()
     {
         isKronoEnd = false;
-        Time.timeScale = 1.0f;
+        //Time.timeScale = 1.0f;
     }
 
     public void OnDestroy()

--- a/Assets/Scripts/SelectableBase/SelectableEnemyBase.cs
+++ b/Assets/Scripts/SelectableBase/SelectableEnemyBase.cs
@@ -2,11 +2,11 @@ using UnityEngine;
 
 public abstract class SelectableEnemyBase : MonoBehaviour , IPlayerSelectable
 {
-    protected IPlayerSelectable.SelectType selectType = IPlayerSelectable.SelectType.NONE;
+    protected SelectableType selectType = SelectableType.NONE;
 
     protected void Start()
     {
-        selectType = IPlayerSelectable.SelectType.ENEMY;
+        selectType = SelectableType.ENEMY;
     }
 
     /**
@@ -19,7 +19,7 @@ public abstract class SelectableEnemyBase : MonoBehaviour , IPlayerSelectable
 
     // インターフェースメソッド
     // 自分のタイプを返却
-    public IPlayerSelectable.SelectType GetSelectType()
+    public SelectableType GetSelectableType()
     {
         return selectType;
     }
@@ -41,7 +41,7 @@ public abstract class SelectableEnemyBase : MonoBehaviour , IPlayerSelectable
 
     // インターフェースメソッド
     // 選択中かどうかの判定
-    public bool IsSelect { get; set; }
+    public bool IsSelect { get; protected set; }
 
     // インターフェースメソッド
     // 選択時に行う処理

--- a/Assets/Scripts/SelectableBase/SelectableGimmickObjectBase.cs
+++ b/Assets/Scripts/SelectableBase/SelectableGimmickObjectBase.cs
@@ -1,12 +1,12 @@
-﻿using UnityEngine;
+using UnityEngine;
 
 public abstract class SelectableGimmickObjectBase : MonoBehaviour, IPlayerSelectable
 {
-    protected IPlayerSelectable.SelectType selectType = IPlayerSelectable.SelectType.NONE;
+    protected SelectableType selectType = SelectableType.NONE;
 
     protected void Start()
     {
-        selectType = IPlayerSelectable.SelectType.GIMMICK;
+        selectType = SelectableType.GIMMICK;
     }
 
     /**
@@ -19,7 +19,7 @@ public abstract class SelectableGimmickObjectBase : MonoBehaviour, IPlayerSelect
 
     // インターフェースメソッド
     // 自分のタイプを返却
-    public IPlayerSelectable.SelectType GetSelectType()
+    public SelectableType GetSelectableType()
     {
         return selectType;
     }
@@ -41,7 +41,7 @@ public abstract class SelectableGimmickObjectBase : MonoBehaviour, IPlayerSelect
 
     // インターフェースメソッド
     // 選択中かどうかの判定
-    public bool IsSelect { get; set; }
+    public bool IsSelect { get; protected set; }
 
     // インターフェースメソッド
     // 選択時に行う処理

--- a/Assets/Scripts/SelectableBase/SelectableType.cs
+++ b/Assets/Scripts/SelectableBase/SelectableType.cs
@@ -1,0 +1,8 @@
+using UnityEngine;
+
+public enum SelectableType
+{
+    NONE, // あるだけ
+    GIMMICK, // 取得可能オブジェクト
+    ENEMY // 敵
+}

--- a/Assets/Scripts/SelectableBase/SelectableType.cs.meta
+++ b/Assets/Scripts/SelectableBase/SelectableType.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 334e946001766f44bae2c519bd21dcd8

--- a/Assets/Scripts/Tools.meta
+++ b/Assets/Scripts/Tools.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 258b27ab1a4de9147875f21ae865310e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Tools/TimeControlManager.cs
+++ b/Assets/Scripts/Tools/TimeControlManager.cs
@@ -1,0 +1,40 @@
+﻿using System.Threading;
+using Cysharp.Threading.Tasks;
+using UnityEngine;
+
+public static class TimeControl
+{
+    public static async UniTask KronoDelay(float seconds)
+    {
+        float elapsed = 0;
+        while (elapsed < seconds)
+        {
+            await UniTask.WaitUntil(() => !PlayerKronoEnd.GetIsKronoEnd());
+            elapsed += Time.deltaTime;
+            await UniTask.Yield();
+        }
+    }
+
+    public static async UniTask KronoDelay(float seconds, CancellationToken token)
+    {
+        float elapsed = 0;
+        while (elapsed < seconds)
+        {
+            await UniTask.WaitUntil(() => !PlayerKronoEnd.GetIsKronoEnd(), cancellationToken: token);
+            elapsed += Time.deltaTime;
+            await UniTask.Yield(cancellationToken: token);
+        }
+    }
+
+    public static async UniTask KronoYield()
+    {
+        await UniTask.WaitUntil(() => !PlayerKronoEnd.GetIsKronoEnd());
+        await UniTask.Yield();
+    }
+
+    public static async UniTask KronoYield(CancellationToken token)
+    {
+        await UniTask.WaitUntil(() => !PlayerKronoEnd.GetIsKronoEnd(), cancellationToken: token);
+        await UniTask.Yield(cancellationToken: token);
+    }
+}

--- a/Assets/Scripts/Tools/TimeControlManager.cs.meta
+++ b/Assets/Scripts/Tools/TimeControlManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e3b5d1c78e64952479929916a7331699


### PR DESCRIPTION
## チケット
クロノ・エンド使用時に吹っ飛ぶ動作になる不具合
https://projecteden.atlassian.net/browse/SCRUM-134

## 概要
プロトタイプ第1弾提出後環境にて、クロノ・エンドの使用時、想定していない動作で不具合が発生していたため修正。

## 原因
クロノ・エンド使用時はTimescaleを変更していたため、
それにともなう物理計算に影響が出て、verocityによる移動がうまくできなくなっていた。

## 対応内容
Tijmescaleで敵の動きを止めるのをやめ、
敵側で"動きを止める"という状態を作成することで再現する方法へ変更。

また、コードないの軽微なリファクタリングを行いました。

## 影響範囲
敵
クロノ・エンドのスキル
