### PR TITLE
SCRUM-149 プレイヤー 通常攻撃ヒットストップ量減少

### DIFF
--- a/Assets/Prefabs/Player/Player.prefab
+++ b/Assets/Prefabs/Player/Player.prefab
@@ -130,6 +130,114 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &3280359950559448302
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3246582018037091217}
+  - component: {fileID: 8336341419236828222}
+  - component: {fileID: 560633732388478722}
+  - component: {fileID: 3659482187044653210}
+  m_Layer: 10
+  m_Name: Cube
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3246582018037091217
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3280359950559448302}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.1, z: 1.5}
+  m_LocalScale: {x: 0.5, y: 0.8, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7455311882551154156}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &8336341419236828222
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3280359950559448302}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &560633732388478722
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3280359950559448302}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 1823fc395f3ba3645a41bb2e0d6e0b27, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &3659482187044653210
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3280359950559448302}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &3528744360216756940
 GameObject:
   m_ObjectHideFlags: 0
@@ -164,6 +272,7 @@ Transform:
   m_LocalScale: {x: 1, y: 2, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 3246582018037091217}
   - {fileID: 27430774753516212}
   - {fileID: 6222029953535033007}
   - {fileID: 3666315747485341605}
@@ -312,7 +421,8 @@ MonoBehaviour:
   timeShiftDuration: 5
   playerTimeScale: 0.85
   shiftTimeScale: 0.5
-  attackCoolTime: 1
+  attackCoolTime: 0.5
+  attackBox: {fileID: 3280359950559448302}
   overDriveTime: 10
   kronoEndTime: 7
   maxHP: 10

--- a/Assets/Scenes/PlayerTestScene.unity
+++ b/Assets/Scenes/PlayerTestScene.unity
@@ -3313,6 +3313,11 @@ PrefabInstance:
       propertyPath: cameraObj
       value: 
       objectReference: {fileID: 1509989759}
+    - target: {fileID: 355960402988361258, guid: bec916380ddc5c64695014f2ab91d970,
+        type: 3}
+      propertyPath: attackCoolTime
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 3528744360216756940, guid: bec916380ddc5c64695014f2ab91d970,
         type: 3}
       propertyPath: m_Name

--- a/Assets/Scripts/Player/PlayerAttackCoolTimer.cs
+++ b/Assets/Scripts/Player/PlayerAttackCoolTimer.cs
@@ -83,6 +83,21 @@ public class PlayerAttackCoolTimer
         }
     }
 
+    // クールタイム処理のキャンセル
+    public void CancelCoolDown()
+    {
+        if (!nonAttackable)
+        {
+            // タイマー実行中でない場合即座に処理を終了
+            return;
+        }
+
+        Debug.Log("cancel AttackCoolDown");
+        // キャンセルを受け付けた場合、キャンセルを行う。
+        _nonAttackable = false;
+        attackCoolDownCts.Cancel();
+    }
+
     public void ChangeOverDrive()
     {
         if (nonAttackable)

--- a/Assets/Scripts/Player/PlayerController.cs
+++ b/Assets/Scripts/Player/PlayerController.cs
@@ -41,6 +41,7 @@ public partial class PlayerController : MonoBehaviour, IDamageable, IPlayer
 
     // 攻撃後隙の時間
     [SerializeField] private float attackCoolTime;
+    [SerializeField] private GameObject attackBox;
     private PlayerAttackCoolTimer attackableTimer;
 
     [SerializeField] private float overDriveTime = 10f;
@@ -80,6 +81,7 @@ public partial class PlayerController : MonoBehaviour, IDamageable, IPlayer
 
         attackableTimer = new PlayerAttackCoolTimer(attackCoolTime, overDriveTime);
         attackableTimer.SetPlayer(this.gameObject.transform);
+        attackBox.SetActive(false);
         kronoEnd = new PlayerKronoEnd(kronoEndTime);
 
         lineRenderer.positionCount = 2;
@@ -163,7 +165,14 @@ public partial class PlayerController : MonoBehaviour, IDamageable, IPlayer
             }
             if (input.ReleaseTarget.WasPressedThisFrame())
             {
+                // スペースボタンでターゲットを離れる
                 ReleaseTarget();
+
+                // 攻撃中の場合アニメーションの中断、攻撃硬直を解除
+                if (attackableTimer.nonAttackable)
+                {
+                    attackableTimer.CancelCoolDown();
+                }
             }
             if (input.Sprint.WasReleasedThisFrame())
             {
@@ -259,8 +268,11 @@ public partial class PlayerController : MonoBehaviour, IDamageable, IPlayer
             }
         }
 
-        // 攻撃の後隙を開始する
+        // 攻撃中に、攻撃処理が行われないようにするための待機処理
         attackableTimer.StartAttackCoolDown();
+
+        // 攻撃アニメーションの終了を待機する
+        ViewAttackAnimation().Forget();
     }
 
     private void Jump()
@@ -457,6 +469,29 @@ public partial class PlayerController : MonoBehaviour, IDamageable, IPlayer
         isTimeShifting = false;
         Time.timeScale = 1.0f;
         Destroy(prefab);
+    }
+
+    /// <summary>
+    /// 攻撃状態の可視化の制御
+    /// </summary>
+    /// <returns></returns>
+    private async UniTaskVoid ViewAttackAnimation()
+    {
+        // 攻撃判定の可視化（攻撃アニメーションがある場合、それを再生）
+        attackBox.SetActive(true);
+        float interval = attackCoolTime / 5;
+        float timeoutTimer = 0;
+
+        while (attackableTimer.nonAttackable)
+        {
+            // 攻撃不可能な時間は待機し続ける
+            await UniTask.Delay(TimeSpan.FromSeconds(interval), true);
+            timeoutTimer += interval;
+            // タイムアウトしたらループを抜ける
+            if (timeoutTimer > attackCoolTime + 1f) break;
+        }
+
+        attackBox.SetActive(false);
     }
 
     // オーバードライブ起動


### PR DESCRIPTION
## チケット
https://projecteden.atlassian.net/browse/SCRUM-149

## 概要
攻撃のスピード感をあげるため、攻撃硬直の時間を減少。
攻撃の可視化と、処理の中断を行えるように修正

## 対応内容
攻撃硬直の時間を減少。
攻撃中を可視化するため、攻撃判定のCubeを表示する処理を追加。
スペースボタンでターゲットが外れ移動できるようになったタイミングでも攻撃硬直と攻撃可視化が行われていたため、
スペースボタンでターゲットが外れた時には処理を中断するように修正。

## 影響範囲
・プレイヤー処理クラス
・攻撃硬直処理
