### PR TITLE
SCRUM-170,171 敵と武器ワープ

### DIFF
--- a/Assets/InputAction/PlayerInput.inputactions
+++ b/Assets/InputAction/PlayerInput.inputactions
@@ -112,6 +112,24 @@
                     "processors": "",
                     "interactions": "",
                     "initialStateCheck": false
+                },
+                {
+                    "name": "EnemyWarp",
+                    "type": "Button",
+                    "id": "1762aa09-c709-4eb0-933d-557f26f9081c",
+                    "expectedControlType": "",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "WeaponWarp",
+                    "type": "Button",
+                    "id": "884e5dd3-4ff5-4305-ba44-582e6a0ad4a5",
+                    "expectedControlType": "",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
                 }
             ],
             "bindings": [
@@ -530,6 +548,28 @@
                     "processors": "",
                     "groups": "",
                     "action": "ChronoEnd",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "110e875b-c277-4566-9364-6eb13061bdbb",
+                    "path": "<Keyboard>/leftShift",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "EnemyWarp",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "8ad20663-1c0c-45e4-a0c6-4e6d88c4dfb5",
+                    "path": "<Keyboard>/ctrl",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "WeaponWarp",
                     "isComposite": false,
                     "isPartOfComposite": false
                 }

--- a/Assets/Scripts/Manager/SelectableObjectManager.cs
+++ b/Assets/Scripts/Manager/SelectableObjectManager.cs
@@ -15,6 +15,8 @@ public class SelectableObjectManager : MonoBehaviour
     private IPlayerSelectable beforeWatched = null;
     // 前回選択したオブジェクトを保持
     private IPlayerSelectable beforeSelected = null;
+    // 選択するオブジェクトの種類
+    private SelectableType targetType = SelectableType.NONE;
 
     private void Awake()
     {
@@ -50,6 +52,11 @@ public class SelectableObjectManager : MonoBehaviour
         return targetObject;
     }
 
+    public void SetTargetType(SelectableType type)
+    {
+        targetType = type;
+    }
+
     public IPlayerSelectable GetBeforeWatched()
     {
         return beforeWatched;
@@ -63,6 +70,12 @@ public class SelectableObjectManager : MonoBehaviour
     // カメラ上のオブジェクトを選択するメソッド
     private Transform SearchCenterTarget()
     {
+        if (targetType == SelectableType.NONE)
+        {
+            beforeWatched?.AllowSelection(false);
+            return null;
+        }
+
         float search_radius = 10f;
         // center指定した大正からSphereCastでhitしたものを取得
         var hits = Physics.SphereCastAll(
@@ -129,6 +142,7 @@ public class SelectableObjectManager : MonoBehaviour
         })
         .Where(hit => hit.GetComponent<IPlayerSelectable>() != null)
         .Where(hit => !hit.GetComponent<IPlayerSelectable>().IsSelect)
+        .Where(hit => hit.GetComponent<IPlayerSelectable>().GetSelectableType() == targetType)
         .ToList();
     }
 
@@ -143,6 +157,11 @@ public class SelectableObjectManager : MonoBehaviour
             // 前回のオブジェクトと今回のオブジェクトが違う場合
             // 選択候補になっているオブジェクトを入れ替え
             beforeWatched.AllowSelection(false);
+            nowWatch.AllowSelection(true);
+            beforeWatched = nowWatch;
+        }
+        else if (existBeforeWatched && beforeWatched == nowWatch)
+        {
             nowWatch.AllowSelection(true);
             beforeWatched = nowWatch;
         }

--- a/Assets/Scripts/Player/PlayerController.cs
+++ b/Assets/Scripts/Player/PlayerController.cs
@@ -22,6 +22,7 @@ public partial class PlayerController : MonoBehaviour, IDamageable, IPlayer
 
     // 武器を拾うシステム
     [SerializeField] private WeaponManager weaponManager;
+    private SelectableWeaponBase currentWeapon = null;
 
     // ワープターゲットを可視化する線
     [SerializeField] private LineRenderer lineRenderer;
@@ -44,6 +45,7 @@ public partial class PlayerController : MonoBehaviour, IDamageable, IPlayer
 
     [SerializeField] private float overDriveTime = 10f;
     [SerializeField] private float kronoEndTime = 7f;
+    [SerializeField] private float warpFloatTime = 1f;
     private PlayerKronoEnd kronoEnd;
     private bool isKronoEnd = false;
 
@@ -52,10 +54,10 @@ public partial class PlayerController : MonoBehaviour, IDamageable, IPlayer
     [SerializeField, ReadOnly] private float currentHP;
     [SerializeField, ReadOnly] private float atk = 5;
 
-    private bool isFixed = false;
-    private bool isInput = false;
     private bool isDead = false;
     private bool isStunned = false;
+    private bool isTargetingEnemy = false;
+    private bool isTargetingWeapon = false;
 
     private PlayerInput_Controller.PlayerInputActions input;
 
@@ -81,6 +83,7 @@ public partial class PlayerController : MonoBehaviour, IDamageable, IPlayer
         moveSensitivity.Init();
         playerJump.Reset();
         playerAirAccele.Reset();
+        isTargetingWeapon = true;
 
         attackableTimer = new PlayerAttackCoolTimer(attackCoolTime, overDriveTime);
         attackableTimer.SetPlayer(this.gameObject.transform);
@@ -95,6 +98,7 @@ public partial class PlayerController : MonoBehaviour, IDamageable, IPlayer
         lineRenderer.enabled = false;
 
         selectableManager = SelectableObjectManager.instance;
+        selectableManager.SetTargetType(SelectableType.GIMMICK);
         Cursor.lockState = CursorLockMode.Locked;
     }
 
@@ -127,60 +131,83 @@ public partial class PlayerController : MonoBehaviour, IDamageable, IPlayer
             return;
         }
 
-        // プレイヤーが固定されているとき(密着時)
-        if (!isFixed)
-        {
-            if(!isInput)
-            {
-                if (playerJump.IsJump())
-                {
-                    if (playerAirAccele.CanAction() && input.AirAccele.WasPressedThisFrame())
-                    {
-                        playerAirAccele.CountUpAction();
-                        AirAccele();
-                    }
-                }
-                if (input.Move.ReadValue<Vector2>().magnitude > 0.1f)
-                {
-                    Move();
-                }
+        // new inputs
 
-                if (input.Jump.WasPressedThisFrame())
-                {
-                    if (playerJump.CanJump())
-                    {
-                        playerJump.CountUpJump();
-                        Jump();
-                    }
-                }
-                if (input.TimeShift.WasPressedThisFrame() && !isTimeShifting)
-                {
-                    TimeShift().Forget();
-                }
+        if (currentWeapon != null)
+        {
+            if (input.WeaponWarp.IsPressed() && !isTargetingEnemy && !isTargetingWeapon)
+            {
+                isTargetingWeapon = true;
+                selectableManager.SetTargetType(SelectableType.GIMMICK);
+            }
+            else if (input.EnemyWarp.IsPressed() && !isTargetingEnemy && !isTargetingWeapon && currentWeapon is not GunWeapon)
+            {
+                isTargetingEnemy = true;
+                selectableManager.SetTargetType(SelectableType.ENEMY);
+            }
+
+            if (input.WeaponWarp.WasReleasedThisFrame() && isTargetingWeapon)
+            {
+                isTargetingWeapon = false;
+                selectableManager.SetTargetType(SelectableType.NONE);
+            }
+            else if(input.EnemyWarp.WasReleasedThisFrame() && isTargetingEnemy)
+            {
+                isTargetingEnemy = false;
+                selectableManager.SetTargetType(SelectableType.NONE);
             }
         }
-        else
-        {
-            if(input.Attack.WasPressedThisFrame())
-            {
-                Attack();
-            }
-            if (input.ReleaseTarget.WasPressedThisFrame())
-            {
-                // スペースボタンでターゲットを離れる
-                ReleaseTarget();
 
-                // 攻撃中の場合アニメーションの中断、攻撃硬直を解除
-                if (attackableTimer.nonAttackable)
-                {
-                    attackableTimer.CancelCoolDown();
-                }
-            }
-            if (input.Move.ReadValue<Vector2>().magnitude > 0.1f)
+        if (input.Attack.WasPressedThisFrame())
+        {
+            if (currentWeapon == null)
             {
-                ReleaseTarget();
-                Move();
+                // weapon warp check
+                TelepotationTarget();
+                return;
             }
+
+            if (isTargetingWeapon)
+            {
+                // warp check
+                TelepotationTarget();
+                return;
+            }
+            else if (isTargetingEnemy)
+            {
+                // enemy warp check
+                TelepotationTarget();
+                return;
+            }
+
+            Attack();
+        }
+
+
+        if (playerJump.IsJump())
+        {
+            if (playerAirAccele.CanAction() && input.AirAccele.WasPressedThisFrame())
+            {
+                playerAirAccele.CountUpAction();
+                AirAccele();
+            }
+        }
+        if (input.Move.ReadValue<Vector2>().magnitude > 0.1f)
+        {
+            Move();
+        }
+        if (input.Jump.WasPressedThisFrame())
+        {
+            if (playerJump.CanJump())
+            {
+                playerJump.CountUpJump();
+                Jump();
+            }
+        }
+
+        if (input.TimeShift.WasPressedThisFrame() && !isTimeShifting)
+        {
+            TimeShift().Forget();
         }
 
         if (input.Move.ReadValue<Vector2>().magnitude < 0.1f)
@@ -188,11 +215,7 @@ public partial class PlayerController : MonoBehaviour, IDamageable, IPlayer
             moveSensitivity.Reset();
         }
 
-        var isInteract = isFixed ? input.Interact.WasPressedThisFrame() : input.Attack.WasPressedThisFrame();
-        if (isInteract)
-        {
-            ReleaseKeyTelepotationTarget(isFixed).Forget();
-        }
+        SearchTarget();
 
         // テストコード
         // プロトタイプでスキルの起動を行うためのコード
@@ -211,18 +234,20 @@ public partial class PlayerController : MonoBehaviour, IDamageable, IPlayer
         // ---------------------------ここまで---------------------------
     }
 
-    async UniTask ReleaseKeyTelepotationTarget(bool isFixed)
+    async UniTask WarpFloat()
     {
-        isInput = true;
-        // キーが離れるまでの間ターゲットを探し続ける
-        while (isFixed ? input.Interact.IsPressed() : input.Attack.IsPressed())
+        float endTime = Time.time + warpFloatTime;
+
+        // Use while to wait until time passes
+        while (Time.time < endTime)
         {
-            SearchTarget();
-            await UniTask.WaitForEndOfFrame();
+            if (input.Move.IsPressed())
+            {
+                break;
+            }
+            await UniTask.Yield();
         }
-        isInput = false;
-        lineRenderer.enabled = false;
-        TelepotationTarget();
+        rbody.isKinematic = false;
     }
 
     // プレイヤー移動
@@ -244,7 +269,6 @@ public partial class PlayerController : MonoBehaviour, IDamageable, IPlayer
         var moveVelocity = moveDirection * moveSensitivity.Sensitivity;
         rbody.linearVelocity = new Vector3(moveVelocity.x, rbody.linearVelocity.y, moveVelocity.z);
         transform.rotation = Quaternion.LookRotation(moveDirection);
-        //Debug.Log(rbody.linearVelocity);
     }
 
     private void Attack()
@@ -280,9 +304,6 @@ public partial class PlayerController : MonoBehaviour, IDamageable, IPlayer
                 if (selectableObj != null)
                 {
                     selectableObj.OnRelease();
-                    isFixed = false;
-                    rbody.isKinematic = false;
-                    Debug.Log("fixed");
                 }
                 damageObj.Death();
             }
@@ -322,13 +343,6 @@ public partial class PlayerController : MonoBehaviour, IDamageable, IPlayer
         return hits.Count > 0;
     }
 
-    private void ReleaseTarget()
-    {
-        SelectableObjectManager.instance.ReleaseTarget();
-        isFixed = false;
-        rbody.isKinematic = false;
-    }
-
     public bool Damage(float damage, Vector3 hitPosition)
     {
         currentHP -= damage;
@@ -337,8 +351,6 @@ public partial class PlayerController : MonoBehaviour, IDamageable, IPlayer
         {
             return true;
         }
-
-        ReleaseTarget();
 
         isStunned = true;
 
@@ -362,13 +374,11 @@ public partial class PlayerController : MonoBehaviour, IDamageable, IPlayer
         Vector3 warpPos;
         rbody.linearVelocity = Vector3.zero;
         moveSensitivity.Reset();
-        rbody.isKinematic = true;
         var dir = new Vector3(targetObj.position.x, 0, targetObj.position.z) - new Vector3(transform.position.x, 0, transform.position.z);
         transform.rotation = Quaternion.LookRotation(dir);
         warpPos = targetObj.position - dir.normalized;
         transform.position = warpPos;
         WarpShadow(currentPos, warpPos);
-        isFixed = true;
     }
 
     private void AirAccele()
@@ -411,16 +421,23 @@ public partial class PlayerController : MonoBehaviour, IDamageable, IPlayer
             if (weapon != null)
             {
                 weaponManager.ChangeWeapon(weapon);
-                var weaponData = target.GetComponent<SelectableWeaponBase>().GetWeaponData();
+                currentWeapon = target.GetComponent<SelectableWeaponBase>();
+                var weaponData = currentWeapon.GetWeaponData();
                 if (weaponData != null)
                 {
                     atk = weaponData.damage;
                     attackRange = weaponData.attackRange;
                 }
+                isTargetingWeapon = false;
+                selectableManager.SetTargetType(SelectableType.NONE);
             }
             else
             {
                 Attack();
+                rbody.isKinematic = true;
+                WarpFloat().Forget();
+                isTargetingEnemy = false;
+                selectableManager.SetTargetType(SelectableType.NONE);
             }
         }
     }

--- a/Assets/Scripts/Player/PlayerInput_Controller.cs
+++ b/Assets/Scripts/Player/PlayerInput_Controller.cs
@@ -198,6 +198,24 @@ public partial class @PlayerInput_Controller: IInputActionCollection2, IDisposab
                     ""processors"": """",
                     ""interactions"": """",
                     ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""EnemyWarp"",
+                    ""type"": ""Button"",
+                    ""id"": ""1762aa09-c709-4eb0-933d-557f26f9081c"",
+                    ""expectedControlType"": """",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
+                },
+                {
+                    ""name"": ""WeaponWarp"",
+                    ""type"": ""Button"",
+                    ""id"": ""884e5dd3-4ff5-4305-ba44-582e6a0ad4a5"",
+                    ""expectedControlType"": """",
+                    ""processors"": """",
+                    ""interactions"": """",
+                    ""initialStateCheck"": false
                 }
             ],
             ""bindings"": [
@@ -618,6 +636,28 @@ public partial class @PlayerInput_Controller: IInputActionCollection2, IDisposab
                     ""action"": ""ChronoEnd"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""110e875b-c277-4566-9364-6eb13061bdbb"",
+                    ""path"": ""<Keyboard>/leftShift"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": """",
+                    ""action"": ""EnemyWarp"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""8ad20663-1c0c-45e4-a0c6-4e6d88c4dfb5"",
+                    ""path"": ""<Keyboard>/ctrl"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": """",
+                    ""action"": ""WeaponWarp"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
                 }
             ]
         }
@@ -638,6 +678,8 @@ public partial class @PlayerInput_Controller: IInputActionCollection2, IDisposab
         m_PlayerInput_TimeShift = m_PlayerInput.FindAction("TimeShift", throwIfNotFound: true);
         m_PlayerInput_OverDrive = m_PlayerInput.FindAction("OverDrive", throwIfNotFound: true);
         m_PlayerInput_ChronoEnd = m_PlayerInput.FindAction("ChronoEnd", throwIfNotFound: true);
+        m_PlayerInput_EnemyWarp = m_PlayerInput.FindAction("EnemyWarp", throwIfNotFound: true);
+        m_PlayerInput_WeaponWarp = m_PlayerInput.FindAction("WeaponWarp", throwIfNotFound: true);
     }
 
     ~@PlayerInput_Controller()
@@ -730,6 +772,8 @@ public partial class @PlayerInput_Controller: IInputActionCollection2, IDisposab
     private readonly InputAction m_PlayerInput_TimeShift;
     private readonly InputAction m_PlayerInput_OverDrive;
     private readonly InputAction m_PlayerInput_ChronoEnd;
+    private readonly InputAction m_PlayerInput_EnemyWarp;
+    private readonly InputAction m_PlayerInput_WeaponWarp;
     /// <summary>
     /// Provides access to input actions defined in input action map "PlayerInput".
     /// </summary>
@@ -789,6 +833,14 @@ public partial class @PlayerInput_Controller: IInputActionCollection2, IDisposab
         /// Provides access to the underlying input action "PlayerInput/ChronoEnd".
         /// </summary>
         public InputAction @ChronoEnd => m_Wrapper.m_PlayerInput_ChronoEnd;
+        /// <summary>
+        /// Provides access to the underlying input action "PlayerInput/EnemyWarp".
+        /// </summary>
+        public InputAction @EnemyWarp => m_Wrapper.m_PlayerInput_EnemyWarp;
+        /// <summary>
+        /// Provides access to the underlying input action "PlayerInput/WeaponWarp".
+        /// </summary>
+        public InputAction @WeaponWarp => m_Wrapper.m_PlayerInput_WeaponWarp;
         /// <summary>
         /// Provides access to the underlying input action map instance.
         /// </summary>
@@ -851,6 +903,12 @@ public partial class @PlayerInput_Controller: IInputActionCollection2, IDisposab
             @ChronoEnd.started += instance.OnChronoEnd;
             @ChronoEnd.performed += instance.OnChronoEnd;
             @ChronoEnd.canceled += instance.OnChronoEnd;
+            @EnemyWarp.started += instance.OnEnemyWarp;
+            @EnemyWarp.performed += instance.OnEnemyWarp;
+            @EnemyWarp.canceled += instance.OnEnemyWarp;
+            @WeaponWarp.started += instance.OnWeaponWarp;
+            @WeaponWarp.performed += instance.OnWeaponWarp;
+            @WeaponWarp.canceled += instance.OnWeaponWarp;
         }
 
         /// <summary>
@@ -898,6 +956,12 @@ public partial class @PlayerInput_Controller: IInputActionCollection2, IDisposab
             @ChronoEnd.started -= instance.OnChronoEnd;
             @ChronoEnd.performed -= instance.OnChronoEnd;
             @ChronoEnd.canceled -= instance.OnChronoEnd;
+            @EnemyWarp.started -= instance.OnEnemyWarp;
+            @EnemyWarp.performed -= instance.OnEnemyWarp;
+            @EnemyWarp.canceled -= instance.OnEnemyWarp;
+            @WeaponWarp.started -= instance.OnWeaponWarp;
+            @WeaponWarp.performed -= instance.OnWeaponWarp;
+            @WeaponWarp.canceled -= instance.OnWeaponWarp;
         }
 
         /// <summary>
@@ -1022,5 +1086,19 @@ public partial class @PlayerInput_Controller: IInputActionCollection2, IDisposab
         /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
         /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
         void OnChronoEnd(InputAction.CallbackContext context);
+        /// <summary>
+        /// Method invoked when associated input action "EnemyWarp" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+        /// </summary>
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+        void OnEnemyWarp(InputAction.CallbackContext context);
+        /// <summary>
+        /// Method invoked when associated input action "WeaponWarp" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+        /// </summary>
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
+        void OnWeaponWarp(InputAction.CallbackContext context);
     }
 }

--- a/Assets/Scripts/Weapon/AxeWeapon.cs
+++ b/Assets/Scripts/Weapon/AxeWeapon.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 public class AxeWeapon : SelectableWeaponBase
 {
     // ガード中に攻撃を受けたとき OnGuardSuccess() 経由で true になる
-    private bool _isCounterReady = false;
+    private bool isCounterReady = false;
     protected override void OnAttackCombo(int comboStep)
     {
         // 連続攻撃で挙動が変わるようであれば以下のように使う
@@ -20,17 +20,17 @@ public class AxeWeapon : SelectableWeaponBase
     // 右クリック長押し開始時
     public override void OnHoldStart()
     {
-        _isCounterReady = false;
+        isCounterReady = false;
         // ガード開始
     }
 
     // 右クリック長押し解除時
     public override void OnHoldEnd()
     {
-        if (_isCounterReady)
+        if (isCounterReady)
         {
             // カウンター薙ぎ払い
-            _isCounterReady = false;
+            isCounterReady = false;
         }
         else
         {
@@ -41,7 +41,7 @@ public class AxeWeapon : SelectableWeaponBase
     // 攻撃判定側からガード成功を通知する。OnHoldEnd 時にカウンター攻撃に切り替わる
     public void OnGuardSuccess()
     {
-        _isCounterReady = true;
+        isCounterReady = true;
     }
 
     // コンボによる段階ゲージによって変わる攻撃

--- a/Assets/Scripts/Weapon/GunWeapon.cs
+++ b/Assets/Scripts/Weapon/GunWeapon.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 public class GunWeapon : SelectableWeaponBase
 {
     // エイム中かどうかを表す状態。アニメーションや UI への通知に使う
-    private bool _isAiming = false;
+    private bool isAiming = false;
 
     protected override void OnAttackCombo(int comboStep)
     {
@@ -16,14 +16,14 @@ public class GunWeapon : SelectableWeaponBase
     // 右クリック長押し開始時
     public override void OnHoldStart()
     {
-        _isAiming = true;
+        isAiming = true;
         // エイム開始
     }
 
     // 右クリック長押し解除時
     public override void OnHoldEnd()
     {
-        _isAiming = false;
+        isAiming = false;
         // エイム解除
     }
 

--- a/Assets/Scripts/Weapon/SpearWeapon.cs
+++ b/Assets/Scripts/Weapon/SpearWeapon.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 public class SpearWeapon : SelectableWeaponBase
 {
     // エイム中かどうかを表す状態。アニメーションや UI への通知に使う
-    private bool _isAiming = false;
+    private bool isAiming = false;
 
     protected override void OnAttackCombo(int comboStep)
     {
@@ -20,14 +20,14 @@ public class SpearWeapon : SelectableWeaponBase
     // 右クリック長押し開始時
     public override void OnHoldStart()
     {
-        _isAiming = true;
+        isAiming = true;
         // エイム開始
     }
 
     // 右クリック長押し解除時
     public override void OnHoldEnd()
     {
-        _isAiming = false;
+        isAiming = false;
         // エイム解除 → 槍投げ
     }
 


### PR DESCRIPTION
## チケット
https://projecteden.atlassian.net/browse/SCRUM-170

## 概要
ワープ可能な敵の索敵用入力キーと敵ワープの実装
ワープ可能な武器の索敵用入力キーと武器ワープの実装
以前あったワープ後敵にくっつく機能削除
敵ワープ後１秒だけ浮く機能作成（移動すると解除）

## 対応内容
プレイヤーの入力回りのスクリプトの構造を変更
ワープ可能な相手の表示を武器と敵で分けた
くっつく機能はUnitaskで実装

## 影響範囲
PlayerController
SelectableObjectManager
PlayerInputActions