### PR TITLE
SCRUM-193 プレイヤー 基本操作 カメラ操作

### DIFF
--- a/Assets/Scenes/PlayerTestScene.unity
+++ b/Assets/Scenes/PlayerTestScene.unity
@@ -1216,7 +1216,9 @@ GameObject:
   - component: {fileID: 1159068689}
   - component: {fileID: 1159068693}
   - component: {fileID: 1159068692}
+  - component: {fileID: 1159068695}
   - component: {fileID: 1159068691}
+  - component: {fileID: 1159068694}
   m_Layer: 0
   m_Name: Third Person Aim Camera
   m_TagString: Untagged
@@ -1276,7 +1278,7 @@ Transform:
   m_GameObject: {fileID: 1159068686}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 1, z: -5}
+  m_LocalPosition: {x: 0, y: 1.5, z: -5.5}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -1356,7 +1358,7 @@ MonoBehaviour:
   TiltAxis:
     Value: 0
     Center: 0
-    Range: {x: -70, y: 70}
+    Range: {x: -60, y: 45}
     Wrap: 0
     Recentering:
       Enabled: 0
@@ -1387,13 +1389,65 @@ MonoBehaviour:
       Size: {x: 0.8, y: 0.8}
       Offset: {x: 0, y: 0}
   CenterOnActivate: 1
-  TargetOffset: {x: 0, y: 0, z: 0}
+  TargetOffset: {x: 0, y: 0.5, z: -0.5}
   Damping: {x: 1, y: 1, z: 1}
   Lookahead:
     Enabled: 0
     Time: 0
     Smoothing: 0
     IgnoreY: 0
+--- !u!114 &1159068694
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1159068686}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0a2422372bb4af649a98215fa6e702f0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  sensitivity: 5
+--- !u!114 &1159068695
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1159068686}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dbe43d662878a7c43bcd44d43c9e2094, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  CollideAgainst:
+    serializedVersion: 2
+    m_Bits: 8119
+  IgnoreTag: Player
+  TransparentLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  MinimumDistanceFromTarget: 0.3
+  AvoidObstacles:
+    Enabled: 1
+    DistanceLimit: 0
+    MinimumOcclusionTime: 0
+    CameraRadius: 0.4
+    UseFollowTarget:
+      Enabled: 0
+      YOffset: 0
+    Strategy: 0
+    MaximumEffort: 4
+    SmoothingTime: 0
+    Damping: 0.4
+    DampingWhenOccluded: 0.2
+  ShotQualityEvaluation:
+    Enabled: 0
+    OptimalDistance: 10
+    NearLimit: 5
+    FarLimit: 30
+    MaxQualityBoost: 0.2
 --- !u!4 &1160818709 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 6370625171675519867, guid: b085d145631ce824b82f8fcea9738ab1,
@@ -1992,7 +2046,7 @@ Transform:
   m_GameObject: {fileID: 1509989756}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 1, z: -5}
+  m_LocalPosition: {x: 0, y: 1.5, z: -5.5}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []

--- a/Assets/Scenes/PlayerTestScene.unity
+++ b/Assets/Scenes/PlayerTestScene.unity
@@ -1231,7 +1231,9 @@ GameObject:
   - component: {fileID: 1159068689}
   - component: {fileID: 1159068693}
   - component: {fileID: 1159068692}
+  - component: {fileID: 1159068695}
   - component: {fileID: 1159068691}
+  - component: {fileID: 1159068694}
   m_Layer: 0
   m_Name: Third Person Aim Camera
   m_TagString: Untagged
@@ -1291,7 +1293,7 @@ Transform:
   m_GameObject: {fileID: 1159068686}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 1, z: -5}
+  m_LocalPosition: {x: 0, y: 1.5, z: -5.5}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -1371,7 +1373,7 @@ MonoBehaviour:
   TiltAxis:
     Value: 0
     Center: 0
-    Range: {x: -70, y: 70}
+    Range: {x: -60, y: 45}
     Wrap: 0
     Recentering:
       Enabled: 0
@@ -1402,13 +1404,65 @@ MonoBehaviour:
       Size: {x: 0.8, y: 0.8}
       Offset: {x: 0, y: 0}
   CenterOnActivate: 1
-  TargetOffset: {x: 0, y: 0, z: 0}
+  TargetOffset: {x: 0, y: 0.5, z: -0.5}
   Damping: {x: 1, y: 1, z: 1}
   Lookahead:
     Enabled: 0
     Time: 0
     Smoothing: 0
     IgnoreY: 0
+--- !u!114 &1159068694
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1159068686}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0a2422372bb4af649a98215fa6e702f0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  sensitivity: 5
+--- !u!114 &1159068695
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1159068686}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dbe43d662878a7c43bcd44d43c9e2094, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  CollideAgainst:
+    serializedVersion: 2
+    m_Bits: 8119
+  IgnoreTag: Player
+  TransparentLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  MinimumDistanceFromTarget: 0.3
+  AvoidObstacles:
+    Enabled: 1
+    DistanceLimit: 0
+    MinimumOcclusionTime: 0
+    CameraRadius: 0.4
+    UseFollowTarget:
+      Enabled: 0
+      YOffset: 0
+    Strategy: 0
+    MaximumEffort: 4
+    SmoothingTime: 0
+    Damping: 0.4
+    DampingWhenOccluded: 0.2
+  ShotQualityEvaluation:
+    Enabled: 0
+    OptimalDistance: 10
+    NearLimit: 5
+    FarLimit: 30
+    MaxQualityBoost: 0.2
 --- !u!4 &1160818709 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 6370625171675519867, guid: b085d145631ce824b82f8fcea9738ab1,
@@ -2007,7 +2061,7 @@ Transform:
   m_GameObject: {fileID: 1509989756}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 1, z: -5}
+  m_LocalPosition: {x: 0, y: 1.5, z: -5.5}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []

--- a/Assets/Scripts/Camera/CameraSensitivityController.cs
+++ b/Assets/Scripts/Camera/CameraSensitivityController.cs
@@ -1,0 +1,44 @@
+using Unity.Cinemachine;
+using UnityEngine;
+
+/// <summary>
+/// Cinemachineカメラの感度を外部から制御する。
+/// Third Person Aim Camera にアタッチして使用する
+/// </summary>
+public class CameraSensitivityController : MonoBehaviour
+{
+    [SerializeField, Range(1, 10)] private int sensitivity = 5;
+
+    private CinemachineInputAxisController axisController;
+
+    private void Awake()
+    {
+        axisController = GetComponent<CinemachineInputAxisController>();
+        ApplySensitivity();
+    }
+
+    /// <summary>
+    /// オプション画面から感度を設定する（1〜10）
+    /// </summary>
+    public void SetSensitivity(int value)
+    {
+        sensitivity = Mathf.Clamp(value, 1, 10);
+        ApplySensitivity();
+    }
+
+    /// <summary>
+    /// sensitivityの値をCinemachineのGainに反映する
+    /// </summary>
+    private void ApplySensitivity()
+    {
+        if (axisController == null)
+        {
+            return;
+        }
+
+        foreach (InputAxisControllerBase<CinemachineInputAxisController.Reader>.Controller controller in axisController.Controllers)
+        {
+            controller.Input.Gain = sensitivity;
+        }
+    }
+}

--- a/Assets/Scripts/Camera/CameraSensitivityController.cs.meta
+++ b/Assets/Scripts/Camera/CameraSensitivityController.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0a2422372bb4af649a98215fa6e702f0


### PR DESCRIPTION
## チケット
https://projecteden.atlassian.net/browse/SCRUM-193

## 概要
カメラ操作の設定を変更した。

カメラシステムの構成、変更方法の詳細については以下を参照
https://drive.google.com/file/d/13-_U-NGY1ycq1USGFp-ItHt6qmRKaUR1/view?usp=drive_link

## 対応内容
①以下の仕様に基づいて、カメラ周りのコンポーネントの値を変更。
■挙動定義 
三人称追従カメラ
追従基準: プレイヤーキャラクターの背後を基本位置とする

■可動範囲（仰俯角制限）
見上げ（仰角）: 最大 60° 
見下ろし（俯角）: 最大 45° 
 
カメラコリジョン: カメラとキャラクターの間に壁（不透過オブジェクト）が挟まった場合、
カメラのレイキャスト（Raycast）が衝突を検知し、壁の内側までカメラ位置を前方に押し出す。
またはティザリング処理を使用し、透過させる。

②カメラのセンシビリティの設定を可能にするために、「CameraSensitivityController」を作成

## 影響範囲
カメラのコンポーネント
